### PR TITLE
refactor: change default example to English Example

### DIFF
--- a/src/contestEditor/index.tsx
+++ b/src/contestEditor/index.tsx
@@ -255,7 +255,7 @@ const ContestEditor: FC = () => {
     loadConfigFromDB()
       .then((stored) => {
         if (!stored) {
-          return { ...exampleStatements.SupportedGrammar, images: [] } as ContestWithImages;
+          return { ...exampleStatements["English Example"], images: [] } as ContestWithImages;
         }
 
         // Create blob URLs for loaded images
@@ -274,7 +274,7 @@ const ContestEditor: FC = () => {
           images: imageList,
         } as ContestWithImages;
       })
-      .catch(() => ({ ...exampleStatements.SupportedGrammar, images: [] } as ContestWithImages)),
+      .catch(() => ({ ...exampleStatements["English Example"], images: [] } as ContestWithImages)),
     []
   );
 


### PR DESCRIPTION
Update the default example statement used when no stored config is found or when loading fails from "SupportedGrammar" to "English Example" for better user experience.