### PR TITLE
feat: add responsive mobile layout with bottom tab navigation

### DIFF
--- a/src/contestEditor/MobileTabBar.tsx
+++ b/src/contestEditor/MobileTabBar.tsx
@@ -1,0 +1,35 @@
+import { type FC } from "react";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faPenToSquare, faEye } from "@fortawesome/free-solid-svg-icons";
+
+interface MobileTabBarProps {
+  activeTab: 'editor' | 'preview';
+  onTabChange: (tab: 'editor' | 'preview') => void;
+}
+
+const MobileTabBar: FC<MobileTabBarProps> = ({ activeTab, onTabChange }) => {
+  return (
+    <div className="h-14 flex items-center justify-around bg-white border-t border-gray-200">
+      <button
+        className={`flex flex-col items-center gap-1 px-6 py-2 transition-colors ${
+          activeTab === 'editor' ? 'text-[#1D71B7]' : 'text-gray-400'
+        }`}
+        onClick={() => onTabChange('editor')}
+      >
+        <FontAwesomeIcon icon={faPenToSquare} className="text-lg" />
+        <span className="text-xs">{/* 编辑 */}</span>
+      </button>
+      <button
+        className={`flex flex-col items-center gap-1 px-6 py-2 transition-colors ${
+          activeTab === 'preview' ? 'text-[#1D71B7]' : 'text-gray-400'
+        }`}
+        onClick={() => onTabChange('preview')}
+      >
+        <FontAwesomeIcon icon={faEye} className="text-lg" />
+        <span className="text-xs">{/* 预览 */}</span>
+      </button>
+    </div>
+  );
+};
+
+export default MobileTabBar;

--- a/src/contestEditor/MobileToolbar.tsx
+++ b/src/contestEditor/MobileToolbar.tsx
@@ -1,0 +1,114 @@
+import { type FC } from "react";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faPlus, faGear, faFilePdf, faChevronDown } from "@fortawesome/free-solid-svg-icons";
+import { useTranslation } from "react-i18next";
+import type { ContestWithImages } from "@/types/contest";
+
+interface MobileToolbarProps {
+  contestData: ContestWithImages;
+  activeId: string;
+  onSelectProblem: (key: string) => void;
+  onAddProblem: () => void;
+  onOpenSettings: () => void;
+  onExportPdf: () => void;
+  onExportCurrentProblem?: () => void;
+  exportDisabled: boolean;
+}
+
+const MobileToolbar: FC<MobileToolbarProps> = ({
+  contestData,
+  activeId,
+  onSelectProblem,
+  onAddProblem,
+  onOpenSettings,
+  onExportPdf,
+  onExportCurrentProblem,
+  exportDisabled,
+}) => {
+  const { t } = useTranslation();
+
+  const currentProblem = contestData.problems.find(p => p.key === activeId);
+  const problemLabel = activeId === 'config' ? t('editor:contestConfig')
+    : activeId === 'images' ? t('editor:imageManagement')
+    : currentProblem ? `${String.fromCharCode(65 + contestData.problems.indexOf(currentProblem))}. ${currentProblem.problem.display_name}`
+    : t('editor:selectProblem');
+
+  return (
+    <div className="h-12 flex items-center justify-between px-3 bg-white border-b border-gray-200">
+      {/* Problem Selector */}
+      <div className="dropdown dropdown-bottom">
+        <label tabIndex={0} className="flex items-center gap-2 px-3 py-1.5 bg-gray-50 rounded-lg text-sm max-w-[160px] cursor-pointer">
+          <span className="truncate">{problemLabel}</span>
+          <FontAwesomeIcon icon={faChevronDown} className="text-xs text-gray-400" />
+        </label>
+        <ul tabIndex={0} className="dropdown-content menu p-2 shadow-lg bg-white rounded-box w-56 max-h-[60vh] overflow-y-auto border border-gray-200 mt-1">
+          <li>
+            <button onClick={() => onSelectProblem('config')} className="text-sm">
+              <FontAwesomeIcon icon={faGear} className="w-4" />
+              {t('editor:contestConfig')}
+            </button>
+          </li>
+          {contestData.problems.map((problem, index) => (
+            <li key={problem.key}>
+              <button onClick={() => onSelectProblem(problem.key!)} className="text-sm">
+                <span className="w-5 h-5 flex items-center justify-center bg-gray-100 rounded text-xs font-medium">
+                  {String.fromCharCode(65 + index)}
+                </span>
+                <span className="truncate">{problem.problem.display_name}</span>
+              </button>
+            </li>
+          ))}
+        </ul>
+      </div>
+
+      {/* Actions */}
+      <div className="flex items-center gap-1">
+        <button
+          className="btn btn-ghost btn-sm btn-square"
+          onClick={onAddProblem}
+          title={t('editor:addProblem')}
+        >
+          <FontAwesomeIcon icon={faPlus} />
+        </button>
+
+        <div className="dropdown dropdown-end">
+          <label tabIndex={0} className="btn btn-ghost btn-sm btn-square">
+            <FontAwesomeIcon icon={faFilePdf} />
+          </label>
+          <ul tabIndex={0} className="dropdown-content menu p-2 shadow-lg bg-white rounded-box w-40 border border-gray-200 mt-1">
+            <li>
+              <button
+                onClick={onExportPdf}
+                disabled={exportDisabled}
+                className="text-sm"
+              >
+                {t('common:exportPdf')}
+              </button>
+            </li>
+            {onExportCurrentProblem && activeId !== 'config' && activeId !== 'images' && (
+              <li>
+                <button
+                  onClick={onExportCurrentProblem}
+                  disabled={exportDisabled}
+                  className="text-sm"
+                >
+                  {t('common:exportProblem')}
+                </button>
+              </li>
+            )}
+          </ul>
+        </div>
+
+        <button
+          className="btn btn-ghost btn-sm btn-square"
+          onClick={onOpenSettings}
+          title={t('common:settings')}
+        >
+          <FontAwesomeIcon icon={faGear} />
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default MobileToolbar;

--- a/src/contestEditor/index.css
+++ b/src/contestEditor/index.css
@@ -423,3 +423,16 @@
     grid-template-columns: 1fr;
   }
 }
+
+/* 移动端样式优化 */
+@media (max-width: 767px) {
+  .custom-scroll::-webkit-scrollbar {
+    width: 4px;
+    height: 4px;
+  }
+
+  .custom-scroll::-webkit-scrollbar-thumb {
+    background: #d1d5db;
+    border-radius: 2px;
+  }
+}

--- a/src/hooks/useMediaQuery.ts
+++ b/src/hooks/useMediaQuery.ts
@@ -1,0 +1,28 @@
+import { useState, useEffect } from 'react';
+
+export function useMediaQuery(query: string): boolean {
+  const [matches, setMatches] = useState(() => {
+    if (typeof window !== 'undefined') {
+      return window.matchMedia(query).matches;
+    }
+    return false;
+  });
+
+  useEffect(() => {
+    const mediaQuery = window.matchMedia(query);
+    const handler = (e: MediaQueryListEvent) => setMatches(e.matches);
+
+    setMatches(mediaQuery.matches);
+
+    if (mediaQuery.addEventListener) {
+      mediaQuery.addEventListener('change', handler);
+      return () => mediaQuery.removeEventListener('change', handler);
+    } else {
+      // 兼容旧版浏览器
+      mediaQuery.addListener(handler);
+      return () => mediaQuery.removeListener(handler);
+    }
+  }, [query]);
+
+  return matches;
+}


### PR DESCRIPTION
## Summary
- Add responsive mobile layout with bottom tab switching (editor/preview)
- Create `useMediaQuery` hook for responsive design detection
- Add `MobileToolbar` component for mobile top bar with problem selection
- Add `MobileTabBar` component for editor/preview tab navigation
- Refactor `ContestEditor` to conditionally render desktop/mobile layouts
- Add mobile-specific CSS scrollbar styles

## Test Plan
- [x] Test responsive layout at 768px breakpoint
- [x] Verify mobile toolbar shows problem selector
- [x] Verify bottom tab bar switches between editor and preview
- [x] Verify settings modal works on mobile
- [x] Test PDF export functionality on mobile
- [x] Verify desktop layout still works correctly