### PR TITLE
chore: bump DB version to 26 for version control support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "xcpc-statement-generator",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "xcpc-statement-generator",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "dependencies": {
         "@codemirror/commands": "^6.10.2",
         "@codemirror/lang-markdown": "^6.5.0",

--- a/src/utils/indexedDBUtils.ts
+++ b/src/utils/indexedDBUtils.ts
@@ -3,7 +3,7 @@ import type { Contest, ContestWithImages } from "@/types/contest";
 const DB_NAME = "xcpc-statement-gen-db";
 const CONFIG_STORE = "contest-config";
 const IMAGES_STORE = "images";
-const DB_VERSION = 25; // Bumped to recreate images store with correct schema
+const DB_VERSION = 26; // Must match versionControl.ts
 
 // Image blob storage type
 interface StoredImageData {


### PR DESCRIPTION
## Summary
- Bump IndexedDB version from 25 to 26 to support version control system
- Update package-lock.json version to 0.2.1

## Test plan
- [x] Verify app works correctly with new DB version
- [x] Check that existing contest data migrates properly