### PR TITLE
fix: add error toast when saving version without branch

### DIFF
--- a/src/components/VersionManager.tsx
+++ b/src/components/VersionManager.tsx
@@ -98,7 +98,11 @@ const VersionManager: FC<VersionManagerProps> = ({ currentContest, onRestore, on
 
   // Handle save version
   const handleSaveVersion = async () => {
-    if (!versionName.trim() || !selectedBranchId) return;
+    if (!selectedBranchId) {
+      showToast(t("messages:versionControl.needBranch"), "error");
+      return;
+    }
+    if (!versionName.trim()) return;
 
     const contest: Contest = {
       meta: currentContest.meta,

--- a/src/i18n/locales/en/messages.json
+++ b/src/i18n/locales/en/messages.json
@@ -67,6 +67,7 @@
     "branchBase": "Based on",
     "branchBaseEmpty": "Create from empty",
     "branchBaseVersion": "Create from version",
-    "selectVersion": "Select version"
+    "selectVersion": "Select version",
+    "needBranch": "Please create a branch first"
   }
 }

--- a/src/i18n/locales/zh/messages.json
+++ b/src/i18n/locales/zh/messages.json
@@ -67,6 +67,7 @@
     "branchBase": "基于",
     "branchBaseEmpty": "空白创建",
     "branchBaseVersion": "从版本创建",
-    "selectVersion": "选择版本"
+    "selectVersion": "选择版本",
+    "needBranch": "请先创建分支"
   }
 }


### PR DESCRIPTION
## Summary
- Add error toast when user tries to save version without creating a branch first
- Previously, the save operation would silently fail with no feedback

## Test plan
- [x] Open version manager with no branches
- [x] Click "Save Version" button
- [x] Verify error toast appears with message "请先创建分支" / "Please create a branch first"